### PR TITLE
mongostore and diff saml validator

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@authenio/samlify-node-xmllint": "^2.0.0",
+        "@authenio/samlify-xsd-schema-validator": "^1.0.5",
         "axios": "^1.7.9",
+        "connect-mongo": "^5.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -32,13 +33,13 @@
         "typescript": "^5.7.2"
       }
     },
-    "node_modules/@authenio/samlify-node-xmllint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@authenio/samlify-node-xmllint/-/samlify-node-xmllint-2.0.0.tgz",
-      "integrity": "sha512-V9cQ0CHqu3JwOmbSecGPUnzIES5kHxD00FEZKnWh90ksQUJG5/TscV2r9XLbKp7MlRMOSUfWxecM35xPSLFdSg==",
+    "node_modules/@authenio/samlify-xsd-schema-validator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@authenio/samlify-xsd-schema-validator/-/samlify-xsd-schema-validator-1.0.5.tgz",
+      "integrity": "sha512-HJjmjM1WbeB/z4nVbYEcmtIWTLPKqjrqRGEpC9lu7s03Usc4nxxfrJGjHgh3M8MvBJy4neVUoeM9rP4ym3GLgg==",
       "license": "MIT",
       "dependencies": {
-        "node-xmllint": "^1.0.0"
+        "@authenio/xsd-schema-validator": "^0.7.3"
       },
       "peerDependencies": {
         "samlify": ">= 2.6.0"
@@ -66,6 +67,13 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/@authenio/xsd-schema-validator": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@authenio/xsd-schema-validator/-/xsd-schema-validator-0.7.3.tgz",
+      "integrity": "sha512-Jhc/Hxv90bacZr0Fv+u+PEb440zPh4mO6rw+bzEAIBiFLKCtRa/BvKGRxPdCAwsGRPuwl2hFqQGF+Lfz6Q8kFg==",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -398,6 +406,18 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -434,6 +454,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -617,6 +643,46 @@
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
+    },
+    "node_modules/connect-mongo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
+      }
+    },
+    "node_modules/connect-mongo/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/connect-mongo/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1194,6 +1260,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/kruptein": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.7.tgz",
+      "integrity": "sha512-vTftnEjfbqFHLqxDUMQCj6gBo5lKqjV4f0JsM8rk8rM3xmvFZ2eSy4YALdaye7E+cDKnEj7eAjFR3vwh8a4PgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">8"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1275,6 +1353,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1488,12 +1572,6 @@
       "dependencies": {
         "asn1": "^0.2.4"
       }
-    },
-    "node_modules/node-xmllint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-xmllint/-/node-xmllint-1.0.0.tgz",
-      "integrity": "sha512-71UV2HRUP+djvHpdyatiuv+Y1o8hI4ZI7bMfuuoACMLR1JJCErM4WXAclNeHd6BgHXkqeqnnAk3wpDkSQWmFXw==",
-      "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "3.1.9",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,8 +13,9 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@authenio/samlify-node-xmllint": "^2.0.0",
+    "@authenio/samlify-xsd-schema-validator": "^1.0.5",
     "axios": "^1.7.9",
+    "connect-mongo": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/backend/src/config/samlConfig.ts
+++ b/backend/src/config/samlConfig.ts
@@ -4,9 +4,8 @@ import path from 'path';
 import { IdentityProvider, ServiceProvider } from 'samlify';
 import dotenv from 'dotenv';
 dotenv.config();
-
 import * as samlify from 'samlify';
-import * as validator from '@authenio/samlify-node-xmllint';
+const validator = require('@authenio/samlify-xsd-schema-validator');
 samlify.setSchemaValidator(validator);
 
 export const fetchAndSaveMetadata = async () => {

--- a/backend/src/routes/AuthRoutes.ts
+++ b/backend/src/routes/AuthRoutes.ts
@@ -78,7 +78,8 @@ router.get('/login/saml', async (req: Request, res: Response) => {
           email: extract.attributes[baseLink + 'emailaddress'],
           firstName: extract.attributes[baseLink + 'givenname'],
           lastName: extract.attributes[baseLink + 'surname'],
-          sessionIndex: extract.sessionIndex
+          sessionIndex: extract.sessionIndex,
+          nameID: extract.nameID
         };
         
         console.log('SAML user:', (req.session as any).user);
@@ -111,9 +112,9 @@ router.get('/login/saml', async (req: Request, res: Response) => {
       res.redirect('/');
       return;
     }
-
+    console.log('SAML user logged out:', user.nameID);
     const { id, context } = sp.createLogoutRequest(idp, 'redirect', {
-      sessionIndex: user.samlSessionIndex,
+      sessionIndex: user.sessionIndex.sessionIndex,
       nameID: user.nameID
     });
 


### PR DESCRIPTION
Using MongoStore instead of Express session bcuz it's more reliable and less prone to memory leaks and scales better
Changed libraries where import of saml validator was coming from after running into site crashing trying to parse XML data