### PR TITLE
Fixed backlash inputs in course search

### DIFF
--- a/frontend/src/app/campus/courses/page.tsx
+++ b/frontend/src/app/campus/courses/page.tsx
@@ -128,6 +128,8 @@ const CourseSearchComponent = () => {
                 return;
             }
 
+            const term_cleaned = term.replace(/\\/g, '');
+
             const source = createCancelTokenSource();
 
             try {
@@ -142,7 +144,7 @@ const CourseSearchComponent = () => {
                     `${process.env.BACKEND_LINK}/api/courses`,
                     {
                         params: {
-                            search: term,
+                            search: term_cleaned,
                             number: number,
                             schools: activeSchools.join(','),
                             limit: 100,

--- a/frontend/src/app/campus/instructors/page.tsx
+++ b/frontend/src/app/campus/instructors/page.tsx
@@ -61,6 +61,11 @@ const InstructorSearch = () => {
         return cancelTokenSourceRef.current;
     };
 
+    const formatFullName = (s: string) => {
+        const parts = s.trim().split(/\s+/);
+        return s.includes(',') || parts.length !== 2 ? s : `${parts[1]}, ${parts[0]}`;
+    };
+
     const performSearch = useCallback(async (term: string) => {
         if (!term || term.length < 2) {
             setResults([]);
@@ -78,7 +83,7 @@ const InstructorSearch = () => {
                 `${process.env.BACKEND_LINK}/api/instructors`,
                 {
                     params: {
-                        search: term,
+                        search: formatFullName(term),
                         limit: 50,
                     },
                     timeout: 5000,


### PR DESCRIPTION
- context: when users inputted \ into the course search, it would break the search (ie. \hi\) 
- changes: when the input includes "\", the "\" is removed from the term before the term is queried in backend. This should not affect users as people don't use "\" to search for courses. 
- testing: 
<img width="1141" height="581" alt="Screenshot 2025-09-03 at 9 19 29 AM" src="https://github.com/user-attachments/assets/4271f280-ce5d-4d85-a72f-139a3e7559e3" />
