### PR TITLE
Fix/updated instructor search to take in full name

### DIFF
--- a/frontend/src/app/campus/instructors/page.tsx
+++ b/frontend/src/app/campus/instructors/page.tsx
@@ -63,7 +63,9 @@ const InstructorSearch = () => {
 
     const formatFullName = (s: string) => {
         const parts = s.trim().split(/\s+/);
-        return s.includes(',') || parts.length !== 2 ? s : `${parts[1]}, ${parts[0]}`;
+        return s.includes(',') || parts.length !== 2
+            ? s
+            : `${parts[1]}, ${parts[0]}`;
     };
 
     const performSearch = useCallback(async (term: string) => {


### PR DESCRIPTION
**context:** instructor search was only working for [last_name] or [last_name], [first_name] searches. 

**fix:** if the user inputs two words, then the two words will be formatted as [second_word], [first_word] before being queried. this means that when users input [first_name] [last_name], the query will be [last_name], [first_name]. 

this also means: 
- if user inputs [first_name] [last_name] → it will be reformatted into [last_name], [first_name] before being queried.
- if user inputs [last_name], [first_name] → the query will still work
- if user inputs [last_name] [first_name] → the search will not work

**demo:**
- here is a video demonstrating the three cases above, with the last one not working still 
https://github.com/user-attachments/assets/996b45e3-7528-4ac2-a943-e4e831845357
