### PR TITLE
fixed backslashes crashing the search 

### DIFF
--- a/frontend/src/app/campus/courses/page.tsx
+++ b/frontend/src/app/campus/courses/page.tsx
@@ -129,6 +129,7 @@ const CourseSearchComponent = () => {
                 return;
             }
 
+            const term_cleaned = term.replace(/\\/g, '');
             const source = createCancelTokenSource();
 
             try {
@@ -143,7 +144,7 @@ const CourseSearchComponent = () => {
                     `${process.env.BACKEND_LINK}/api/courses`,
                     {
                         params: {
-                            search: term,
+                            search: term_cleaned,
                             number: number,
                             schools: activeSchools.join(','),
                             limit: 100,


### PR DESCRIPTION
**context:** previously, when users inputted "\" into their search, it would return "failed to fetch items". 

**fix**: before passing the search to backend, all "\" were filtered out. this should not result in any problems because users are not using "\" to look for classes. 

**demo**: inputting "\" no longer crashes the search
<img width="1132" height="580" alt="image" src="https://github.com/user-attachments/assets/b0b43788-cbc8-4624-a5a5-4b0a3e6453ae" />
