### PR TITLE
Fix/different result for trailing spaces

### DIFF
--- a/frontend/src/app/campus/courses/page.tsx
+++ b/frontend/src/app/campus/courses/page.tsx
@@ -129,6 +129,7 @@ const CourseSearchComponent = () => {
                 return;
             }
 
+            const cleanedTerm = term.trim();
             const source = createCancelTokenSource();
 
             try {
@@ -143,7 +144,7 @@ const CourseSearchComponent = () => {
                     `${process.env.BACKEND_LINK}/api/courses`,
                     {
                         params: {
-                            search: term,
+                            search: cleanedTerm,
                             number: number,
                             schools: activeSchools.join(','),
                             limit: 100,


### PR DESCRIPTION
**context:** the search was including trailing spaces in its query. For instance, "history" and "history " returned different results. 

**fix:** I called .trim() on the search term before passing it into the backend query. This removes spaces from both the beginning and end of words, but not the middle. 

**demo**: previously, searching history with many trailing spaces would not return any matches because it was performing a literal search for those spaces. now, the two returns the same results. 
<img width="1138" height="534" alt="Screenshot 2025-09-16 at 12 15 46 AM" src="https://github.com/user-attachments/assets/d2f96161-6ca2-45c4-979d-f52aa8cf4ae8" />
<img width="1121" height="525" alt="Screenshot 2025-09-16 at 12 22 09 AM" src="https://github.com/user-attachments/assets/cd23fd17-2e26-4fbe-8979-acd8edc31d5b" />


