### PR TITLE
fix/school selection ui

### DIFF
--- a/frontend/src/app/campus/courses/page.tsx
+++ b/frontend/src/app/campus/courses/page.tsx
@@ -199,11 +199,31 @@ const CourseSearchComponent = () => {
     }, [searchTerm, courseNumber, selectedSchools, debouncedSearch]);
 
     const handleSchoolToggle = (school: SchoolKey) => {
-        setSelectedSchools((prev) => ({
+        setSelectedSchools((prev) => {
+            const allSelected = Object.values(prev).every(Boolean); 
+
+            if (allSelected) {
+            return Object.fromEntries(
+                Object.keys(prev).map((k) => [k, k === school])
+            ) as typeof prev;
+            }
+
+            const newState = {
             ...prev,
             [school]: !prev[school],
-        }));
-    };
+            };
+
+            const anySelected = Object.values(newState).some(Boolean);
+            
+            if (!anySelected) {
+            return Object.fromEntries(
+                Object.keys(prev).map((k) => [k, true])
+            ) as typeof prev;
+            }
+
+            return newState;
+        });
+        };
 
     const sortedResults = useMemo(() => {
         return [...results].sort((a, b) => a.code.localeCompare(b.code));


### PR DESCRIPTION
**context:** the UI for school selection used to be default all selected, and users can deselect schools. This was causing confusion because people usually clicked on the school they wanted to select (instead of deselect). 

**fix**: the default is that all schools are selected. 
- If the user clicks on one school when all are selected, the four other schools are deselected (leaving the one they clicked on as the only one selected). 
- If at any point no schools are selected, then it returns to the default of all schools being selected. 
- Otherwise, selecting and deselecting works normally. 

**demo**: 
https://github.com/user-attachments/assets/93e3a82e-7572-44c0-b7a7-cb567826652c

