### PR TITLE
Enhance CoursePage: Update instructor display to link each instructor to corresponding professor review

### DIFF
--- a/frontend/src/app/campus/courses/[id]/page.tsx
+++ b/frontend/src/app/campus/courses/[id]/page.tsx
@@ -290,7 +290,10 @@ const CoursePage = () => {
                                             </p>
                                             <div className="flex flex-wrap gap-1 mt-1">
                                                 {instructors
-                                                    .filter((instructor) => instructor?.name)
+                                                    .filter(
+                                                        (instructor) =>
+                                                            instructor?.name
+                                                    )
                                                     .map((instructor) => (
                                                         <div
                                                             key={instructor.id}
@@ -300,7 +303,9 @@ const CoursePage = () => {
                                                                 href={`/campus/instructors/${instructor.id}`}
                                                                 className={`text-sm font-medium`}
                                                             >
-                                                                {instructor.name}
+                                                                {
+                                                                    instructor.name
+                                                                }
                                                             </a>
                                                         </div>
                                                     ))}

--- a/frontend/src/app/campus/courses/[id]/page.tsx
+++ b/frontend/src/app/campus/courses/[id]/page.tsx
@@ -288,14 +288,23 @@ const CoursePage = () => {
                                             <p className="text-gray-600 font-medium">
                                                 Instructors:
                                             </p>
-                                            <p>
+                                            <div className="flex flex-wrap gap-1 mt-1">
                                                 {instructors
-                                                    .map(
-                                                        (instructor) =>
-                                                            instructor.name
-                                                    )
-                                                    .join(', ')}
-                                            </p>
+                                                    .filter((instructor) => instructor?.name)
+                                                    .map((instructor) => (
+                                                        <div
+                                                            key={instructor.id}
+                                                            className={`bg-opacity-20 px-2 py-1 rounded-md border border-opacity-30`}
+                                                        >
+                                                            <a
+                                                                href={`/campus/instructors/${instructor.id}`}
+                                                                className={`text-sm font-medium`}
+                                                            >
+                                                                {instructor.name}
+                                                            </a>
+                                                        </div>
+                                                    ))}
+                                            </div>
                                         </div>
                                     )}
 


### PR DESCRIPTION
This PR introduces changes to have the instructor within the course review link to the corresponding professor's review.
- the instructors listed at the top of course description is now linked to prof review
-Related to Github issue #80 

##Changes
- Change the course/[id] page's instructor.name to href={`/campus/instructors/${instructor.id}`}  {instructor.name}

## Screenshots
- Before: Just plain text course's instructors

https://github.com/user-attachments/assets/1447359d-e58f-4932-abdf-13925577539f


- After: tags with course's instructors that link to corresponding instructor review


https://github.com/user-attachments/assets/4f382787-725d-4325-8c57-485a387c8261

