### PR TITLE
Fix/31-Change Staff Dashboard to show Position rather than Name

### DIFF
--- a/backend/src/routes/admin/StaffRoutes.ts
+++ b/backend/src/routes/admin/StaffRoutes.ts
@@ -10,10 +10,10 @@ const router = express.Router();
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
-// Get all ids and names
+// Get all ids and names and positions of staff members
 router.get('/', async (req: Request, res: Response) => {
     try {
-        const staff = await Staff.find({}, { id: 1, name: 1 });
+        const staff = await Staff.find({}, { id: 1, name: 1, position: 1 });
         res.json(staff);
     } catch (error) {
         res.status(500).json({ message: 'Server error' });

--- a/frontend/src/components/ui/StaffDashboard.tsx
+++ b/frontend/src/components/ui/StaffDashboard.tsx
@@ -212,7 +212,7 @@ const StaffDashboard = () => {
                             </option>
                             {existingMembers.map((member) => (
                                 <option key={member.id} value={member.id}>
-                                    {member.name}
+                                    {member.position}
                                 </option>
                             ))}
                         </select>


### PR DESCRIPTION
## Context

When the Chief of Staff wants to add or update new members, it is annoying to deal with seeing which IDs were used already and having to delete the old members, then add the new ones. It would be much simpler to edit members by just replacing the corresponding position.

https://aspcsoftware.atlassian.net/browse/ASPC-31

## Describe your changes

- Added Position to the general GET all request for staff
- Dispaly based on position rather than name in frontend dashboard

## Testing

<img width="1858" height="867" alt="image" src="https://github.com/user-attachments/assets/99e25ac6-334d-4537-a4c5-a26b68a1753b" />


## Future

Create Email field for Staff members in mongodb and populate them appropriate email. Currently it is included in the position field, but should be separated.