### PR TITLE
ASPC-24: Add public (authenticated) open forum routes

### DIFF
--- a/backend/src/models/Forum.ts
+++ b/backend/src/models/Forum.ts
@@ -31,6 +31,15 @@ interface IForumEvent extends Document {
     ratingUntil: Date;
     ratings: IRating[];
     customQuestions: string[];
+
+    // Methods
+    hasUserRated(userId: string): boolean;
+    getAverageRatings(): {
+        overall: number;
+        wouldRepeat: number;
+        customQuestions: { [key: string]: number };
+        totalResponses: number;
+    };
 }
 
 // Schema for ForumEvent

--- a/backend/src/routes/ForumRoutes.ts
+++ b/backend/src/routes/ForumRoutes.ts
@@ -1,0 +1,170 @@
+import express, { Request, Response } from 'express';
+import { ForumEvent, EventComment } from '../models/Forum';
+import { isAuthenticated } from '../middleware/authMiddleware';
+
+const router = express.Router();
+
+/**
+ * @route   GET /api/openforum
+ * @desc    Get all open forum events with average ratings
+ * @access  Public
+ */
+router.get('/', isAuthenticated, async (req: Request, res: Response) => {
+    try {
+        const events = await ForumEvent.find({});
+        res.json(events);
+    } catch (error) {
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+/**
+ * @route   GET /api/openforum/:id
+ * @desc    Get event details with ratings
+ * @access  Public
+ */
+router.get('/:id', isAuthenticated, async (req: Request, res: Response) => {
+    try {
+        const { id } = req.params;
+
+        const eventData = await ForumEvent.findOne({
+            _id: id,
+        });
+        if (!eventData) {
+            res.status(404).json({ message: 'Event not found' });
+            return;
+        }
+
+        res.json(eventData);
+    } catch (error) {
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+/**
+ * @route   POST /api/openforum/:id/rate
+ * @desc    Add new open forum event rating
+ * @access  Public
+ */
+router.post(
+    '/:id/rate',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+
+            const event = await ForumEvent.findById(id);
+
+            if (!event) {
+                res.status(404).json({ message: 'Event not found' });
+                return;
+            }
+
+            // parse review fields from request
+            const { userId, isAnonymous, overall, wouldRepeat, customRatings } =
+                req.body;
+
+            if (
+                typeof overall !== 'number' ||
+                overall < 1 ||
+                overall > 5 ||
+                typeof wouldRepeat !== 'number' ||
+                wouldRepeat < 1 ||
+                wouldRepeat > 5 ||
+                !Array.isArray(customRatings)
+            ) {
+                res.status(400).json({ message: 'Invalid rating data.' });
+                return;
+            }
+
+            const ratingDate = new Date();
+
+            if (ratingDate > event.ratingUntil) {
+                res.status(403).json({ message: 'Rating period has ended.' });
+                return;
+            }
+
+            if (event.hasUserRated(userId)) {
+                res.status(409).json({
+                    message: 'User has already rated this event.',
+                });
+                return;
+            }
+
+            event.ratings.push({
+                userId: userId,
+                isAnonymous: isAnonymous,
+                overall: overall,
+                wouldRepeat: wouldRepeat,
+                customRatings: customRatings,
+                createdAt: ratingDate,
+            });
+
+            await event.save();
+
+            res.status(201).json({ message: 'Rating saved successfully' });
+        } catch (error) {
+            res.status(400).json({ message: 'Error creating rating' });
+        }
+    }
+);
+
+/**
+ * @route   GET /api/openforum/:id/comments
+ * @desc    Get all comments for an open forum event
+ * @access  Public
+ */
+router.get(
+    '/:id/comments',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+
+            const comments = await EventComment.find({
+                eventId: id,
+                isHidden: false,
+            });
+
+            if (!comments) {
+                res.status(404).json({ message: 'Event not found' });
+                return;
+            }
+
+            res.json(comments);
+        } catch (error) {
+            res.status(500).json({ message: 'Server error' });
+        }
+    }
+);
+
+/**
+ * @route   POST /api/openforum/:id/comment
+ * @desc    Get reviews for a room by building id and room number
+ * @access  Public
+ */
+router.post(
+    '/:id/comment',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+            const { author, isAnonymous, content } = req.body;
+
+            const newComment = new EventComment({
+                eventId: id,
+                author: author,
+                isAnonymous: isAnonymous,
+                content: content,
+            });
+
+            const savedComment = await newComment.save();
+            res.status(201).json(savedComment);
+        } catch (err) {
+            console.error(err);
+            res.status(500).json({ message: 'Server error' });
+        }
+    }
+);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import housingRoutes from './routes/HousingRoutes';
 import coursesRoutes from './routes/CoursesRoutes';
 import instructorsRoutes from './routes/InstructorsRoutes';
 import reviewsRoutes from './routes/ReviewsRoutes';
+import forumRoutes from './routes/ForumRoutes';
 import session from 'express-session';
 import https from 'https';
 import http from 'http';
@@ -106,6 +107,7 @@ app.use('/api/campus/housing', housingRoutes);
 app.use('/api/courses', coursesRoutes);
 app.use('/api/instructors', instructorsRoutes);
 app.use('/api/reviews', reviewsRoutes);
+app.use('/api/openforum', forumRoutes);
 
 const PORT = process.env.PORT || 5000;
 


### PR DESCRIPTION
## Context

[ASPC-24](https://aspcsoftware.atlassian.net/browse/ASPC-24?atlOrigin=eyJpIjoiMzZkZDMxN2Q4MzlmNDUxOGIxOWM0NDc5MDczY2QwMjAiLCJwIjoiaiJ9)

Add routes to view open forum events and comments, and post ratings and comments.

## Describe your changes

Using /api/openforum since /api/events is already used for Engage routes

Routes looking up open forum events by id use the MongoDB objectid field `_id`

## Testing

POST /api/openforum/:id/comment
```
curl -H "Content-Type: application/json" \
     -X POST https://localhost:5000/api/openforum/68cdebc1972df99cf11fa268/comment \
     -d '{"author": "68cdebc1972df99cf11fa267",
           "isAnonymous": false,
           "content": "this was fun"         }' -k
```
Response:
```
{"eventId":"68cdebc1972df99cf11fa268","author":"68cdebc1972df99cf11fa267","isAnonymous":false,"content":"this was fun","isHidden":false,"_id":"68d57e5fb126658404fa09c2","createdAt":"2025-09-25T17:39:43.822Z","updatedAt":"2025-09-25T17:39:43.822Z","__v":0}
```

- **API Routes**: Include curl statements showing success for all new/modified endpoints
- **Unit Tests**: Provide unit tests for helper functions and scripts if needed
- **Screenshots**: Include screenshots showing successful execution of tests
