### PR TITLE
ASPC 33 - Fix Course Search Crashing by grouping Instructor GET Requests

### DIFF
--- a/backend/src/routes/InstructorsRoutes.ts
+++ b/backend/src/routes/InstructorsRoutes.ts
@@ -33,6 +33,38 @@ router.get('/', async (req: Request, res: Response) => {
 });
 
 /**
+ * @route   GET /api/instructors/bulk
+ * @desc    Get multiple instructors by IDs
+ * @access  Public
+ */
+router.get('/bulk', async (req: Request, res: Response) => {
+    try {
+        const { ids } = req.query;
+
+        if (!ids || typeof ids !== 'string') {
+            res.status(400).json({ message: 'IDs parameter is required' });
+            return;
+        }
+
+        const instructorIds = ids.split(',').map((id) => parseInt(id.trim(), 10)).filter((id) => !isNaN(id));
+
+        if (instructorIds.length === 0) {
+            res.status(400).json({ message: 'No valid instructor IDs provided' });
+            return;
+        }
+
+        const instructors = await Instructors.find({
+            id: { $in: instructorIds },
+        });
+
+        res.json(instructors);
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+/**
  * @route   GET /api/instructors/:id
  * @desc    Get instructor information by ID
  * @access  Public


### PR DESCRIPTION
## Context

Fixed ERR_INSUFFICIENT_RESOURCES errors when displaying 100+ course results caused by hundreds of simultaneous HTTP requests to fetch instructor data
Jira ticket: [ASPC-33](https://aspcsoftware.atlassian.net/jira/software/projects/ASPC/boards/1/timeline?selectedIssue=ASPC-33)

## Describe your changes

- Added GET /api/instructors/bulk endpoint to fetch multiple instructors in a single request using MongoDB's $in operator
- Refactored fetchInstructors to use the bulk endpoint instead of individual parallel requests
- Removed redundant instructor fetching from CourseCardComponent since data is now pre-fetched during search
- Instead of o(n*m), it's o(n) where n is # of course and m is instructors within a course

## Testing

https://github.com/user-attachments/assets/5f0c2cca-e3ab-406f-a000-317bab08da76

## Future
It will be even better later with pagination, so there will be only 20 requests at once rather than n courses (currently 100).

