### PR TITLE
ASPC-25 Openforum Admin Routes

### DIFF
--- a/backend/src/models/Forum.ts
+++ b/backend/src/models/Forum.ts
@@ -31,6 +31,15 @@ interface IForumEvent extends Document {
     ratingUntil: Date;
     ratings: IRating[];
     customQuestions: string[];
+
+    // Methods
+    hasUserRated(userId: string): boolean;
+    getAverageRatings(): {
+        overall: number;
+        wouldRepeat: number;
+        customQuestions: { [key: string]: number };
+        totalResponses: number;
+    };
 }
 
 // Schema for ForumEvent

--- a/backend/src/routes/ForumRoutes.ts
+++ b/backend/src/routes/ForumRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { ForumEvent, EventComment } from '../models/Forum';
-import { isAuthenticated } from '../middleware/authMiddleware';
+import { isAuthenticated, isAdmin } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
@@ -140,7 +140,7 @@ router.get(
 
 /**
  * @route   POST /api/openforum/:id/comment
- * @desc    Get reviews for a room by building id and room number
+ * @desc    Add a new comment for an event by event's id
  * @access  Public
  */
 router.post(
@@ -163,6 +163,149 @@ router.post(
         } catch (err) {
             console.error(err);
             res.status(500).json({ message: 'Server error' });
+        }
+    }
+);
+
+// ADMIN ROUTES
+
+/**
+ * @route   POST /api/openforum
+ * @desc    Add new open forum event
+ * @access  Admin
+ */
+router.post('/', isAdmin, async (req: Request, res: Response) => {
+    try {
+        const {
+            title,
+            description,
+            createdBy,
+            staffHost,
+            eventDate,
+            location,
+            ratingUntil,
+            customQuestions,
+        } = req.body;
+
+        if (
+            !title ||
+            !description ||
+            !createdBy ||
+            !eventDate ||
+            !location ||
+            !ratingUntil
+        ) {
+            res.status(400).json({ message: 'Missing required fields.' });
+            return;
+        }
+
+        const event = new ForumEvent({
+            title: title,
+            description: description,
+            createdBy: createdBy,
+            staffHost: staffHost,
+            eventDate: eventDate,
+            location: location,
+            ratingUntil: ratingUntil,
+            ratings: [],
+            customQuestions: customQuestions || [],
+        });
+
+        const savedEvent = await event.save();
+
+        res.status(201).json(savedEvent);
+    } catch (error) {
+        res.status(400).json({ message: 'Error creating new custom event' });
+    }
+});
+
+/**
+ * @route   PUT /api/openforum/:id
+ * @desc    Update existing open forum event by id
+ * @access  Admin
+ */
+router.put('/:id', isAdmin, async (req: Request, res: Response) => {
+    try {
+        const { id } = req.params;
+        const {
+            title,
+            description,
+            createdBy,
+            staffHost,
+            eventDate,
+            location,
+            ratingUntil,
+            customQuestions,
+        } = req.body;
+
+        if (
+            !title ||
+            !description ||
+            !createdBy ||
+            !eventDate ||
+            !location ||
+            !ratingUntil
+        ) {
+            res.status(400).json({ message: 'Missing required fields.' });
+            return;
+        }
+
+        const updatedEvent = await ForumEvent.findByIdAndUpdate(
+            id,
+            {
+                title: title,
+                description: description,
+                createdBy: createdBy,
+                staffHost: staffHost,
+                eventDate: eventDate,
+                location: location,
+                ratingUntil: ratingUntil,
+                customQuestions: customQuestions || [],
+            },
+            { new: true, runValidators: true }
+        );
+
+        if (!updatedEvent) {
+            res.status(404).json({ message: 'Forum event not found.' });
+        }
+
+        res.status(201).json(updatedEvent);
+    } catch (error) {
+        res.status(400).json({ message: 'Error updating event' });
+    }
+});
+
+/**
+ * @route   PATCH /api/openforum/comments/:id/hide
+ * @desc    Hide / unhide a comment by comment id
+ * @access  Admin
+ */
+router.patch(
+    '/comments/:id/hide',
+    isAdmin,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+
+            const comment = await EventComment.findById(id);
+
+            if (!comment) {
+                res.status(400).json({
+                    message: 'Comment does not exist',
+                });
+            } else {
+                comment.isHidden = !comment.isHidden;
+                const updatedComment = await comment.save();
+
+                res.status(201).json({
+                    message: `Comment is now ${updatedComment.isHidden ? 'hidden' : 'visible'}.`,
+                    comment: updatedComment,
+                });
+            }
+        } catch (error) {
+            res.status(400).json({
+                message: 'Error hiding comment',
+            });
         }
     }
 );

--- a/backend/src/routes/ForumRoutes.ts
+++ b/backend/src/routes/ForumRoutes.ts
@@ -1,0 +1,170 @@
+import express, { Request, Response } from 'express';
+import { ForumEvent, EventComment } from '../models/Forum';
+import { isAuthenticated } from '../middleware/authMiddleware';
+
+const router = express.Router();
+
+/**
+ * @route   GET /api/openforum
+ * @desc    Get all open forum events with average ratings
+ * @access  Public
+ */
+router.get('/', isAuthenticated, async (req: Request, res: Response) => {
+    try {
+        const events = await ForumEvent.find({});
+        res.json(events);
+    } catch (error) {
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+/**
+ * @route   GET /api/openforum/:id
+ * @desc    Get event details with ratings
+ * @access  Public
+ */
+router.get('/:id', isAuthenticated, async (req: Request, res: Response) => {
+    try {
+        const { id } = req.params;
+
+        const eventData = await ForumEvent.findOne({
+            _id: id,
+        });
+        if (!eventData) {
+            res.status(404).json({ message: 'Event not found' });
+            return;
+        }
+
+        res.json(eventData);
+    } catch (error) {
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+/**
+ * @route   POST /api/openforum/:id/rate
+ * @desc    Add new open forum event rating
+ * @access  Public
+ */
+router.post(
+    '/:id/rate',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+
+            const event = await ForumEvent.findById(id);
+
+            if (!event) {
+                res.status(404).json({ message: 'Event not found' });
+                return;
+            }
+
+            // parse review fields from request
+            const { userId, isAnonymous, overall, wouldRepeat, customRatings } =
+                req.body;
+
+            if (
+                typeof overall !== 'number' ||
+                overall < 1 ||
+                overall > 5 ||
+                typeof wouldRepeat !== 'number' ||
+                wouldRepeat < 1 ||
+                wouldRepeat > 5 ||
+                !Array.isArray(customRatings)
+            ) {
+                res.status(400).json({ message: 'Invalid rating data.' });
+                return;
+            }
+
+            const ratingDate = new Date();
+
+            if (ratingDate > event.ratingUntil) {
+                res.status(403).json({ message: 'Rating period has ended.' });
+                return;
+            }
+
+            if (event.hasUserRated(userId)) {
+                res.status(409).json({
+                    message: 'User has already rated this event.',
+                });
+                return;
+            }
+
+            event.ratings.push({
+                userId: userId,
+                isAnonymous: isAnonymous,
+                overall: overall,
+                wouldRepeat: wouldRepeat,
+                customRatings: customRatings,
+                createdAt: ratingDate,
+            });
+
+            await event.save();
+
+            res.status(201).json({ message: 'Rating saved successfully' });
+        } catch (error) {
+            res.status(400).json({ message: 'Error creating rating' });
+        }
+    }
+);
+
+/**
+ * @route   GET /api/openforum/:id/comments
+ * @desc    Get all comments for an open forum event
+ * @access  Public
+ */
+router.get(
+    '/:id/comments',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+
+            const comments = await EventComment.find({
+                eventId: id,
+                isHidden: false,
+            });
+
+            if (!comments) {
+                res.status(404).json({ message: 'Event not found' });
+                return;
+            }
+
+            res.json(comments);
+        } catch (error) {
+            res.status(500).json({ message: 'Server error' });
+        }
+    }
+);
+
+/**
+ * @route   POST /api/openforum/:id/comment
+ * @desc    Get reviews for a room by building id and room number
+ * @access  Public
+ */
+router.post(
+    '/:id/comment',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const { id } = req.params;
+            const { author, isAnonymous, content } = req.body;
+
+            const newComment = new EventComment({
+                eventId: id,
+                author: author,
+                isAnonymous: isAnonymous,
+                content: content,
+            });
+
+            const savedComment = await newComment.save();
+            res.status(201).json(savedComment);
+        } catch (err) {
+            console.error(err);
+            res.status(500).json({ message: 'Server error' });
+        }
+    }
+);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import housingRoutes from './routes/HousingRoutes';
 import coursesRoutes from './routes/CoursesRoutes';
 import instructorsRoutes from './routes/InstructorsRoutes';
 import reviewsRoutes from './routes/ReviewsRoutes';
+import forumRoutes from './routes/ForumRoutes';
 import session from 'express-session';
 import https from 'https';
 import http from 'http';
@@ -106,6 +107,7 @@ app.use('/api/campus/housing', housingRoutes);
 app.use('/api/courses', coursesRoutes);
 app.use('/api/instructors', instructorsRoutes);
 app.use('/api/reviews', reviewsRoutes);
+app.use('/api/openforum', forumRoutes);
 
 const PORT = process.env.PORT || 5000;
 


### PR DESCRIPTION
## Context

[ASPC-25](https://aspcsoftware.atlassian.net/browse/ASPC-25)

## Describe your changes

- add 3 new routes for admins to create custom (non-Engage) events, update event data, and hide/unhide comments

## Testing

POST /api/openforum
```
curl -X POST https://localhost:5000/api/openforum \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Test Event",
    "description": "Test description.",
    "createdBy": "123",
    "eventDate": "2025-10-1",
    "location": "Main Auditorium, Building A",
    "ratingUntil": "2025-10-15",
    "customQuestions": [
      "Did you enjoy the event?"
   ]
  }' -k
```

PUT /api/openforum/:id
```
curl -X PUT https://localhost:5000/api/openforum/68db751f5c1b74f3f38078cf \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Test Event UPDATED",
    "description": "UPDATED test description.",
    "createdBy": "68cdebc1972df99cf11fa267",
    "eventDate": "2025-10-1",
    "location": "Main Auditorium, Building B",
    "ratingUntil": "2025-10-16",
    "customQuestions": [
      "new question?"
   ]
  }' -k
```

PATCH /api/openforum/comments/:id/hide
```
curl -X PATCH https://localhost:5000/api/openforum/comments/68d57e5fb126658404fa09c2/hide \
  -H "Content-Type: application/json" -k
```