### PR TITLE
change buildings page to a client component

### DIFF
--- a/frontend/src/app/campus/housing/[id]/[room]/page.tsx
+++ b/frontend/src/app/campus/housing/[id]/[room]/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useEffect, useState, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Loading from '@/components/Loading';

--- a/frontend/src/app/campus/housing/[id]/page.tsx
+++ b/frontend/src/app/campus/housing/[id]/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';

--- a/frontend/src/app/campus/housing/page.tsx
+++ b/frontend/src/app/campus/housing/page.tsx
@@ -1,10 +1,12 @@
-export const runtime = 'nodejs';
+'use client';
 
-import { MongoClient } from 'mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import Loading from '@/components/Loading';
+import { useAuth } from '@/hooks/useAuth';
+import LoginRequired from '@/components/LoginRequired';
 
-// Define types for MongoDB docs and UI data structure
 type BuildingDoc = {
     id: number;
     name: string;
@@ -26,47 +28,104 @@ type CampusGroup = {
     buildings: BuildingCard[];
 };
 
-const HousingPage = async () => {
-    const client = await MongoClient.connect(
-        process.env.MONGODB_URI! || 'mongodb://localhost:27017/school-platform'
-    );
-    const db = client.db('school-platform');
-    const buildings = await db
-        .collection<BuildingDoc>('housingbuildings')
-        .find()
-        .toArray();
-    client.close();
+const HousingPage = () => {
+    const [housingData, setHousingData] = useState<CampusGroup[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const { user, loading: authLoading } = useAuth();
 
-    // Organize buildings by campus
-    const housingData: CampusGroup[] = buildings.reduce((acc, building) => {
-        const campusName =
-            building.campus.charAt(0).toUpperCase() +
-            building.campus.slice(1) +
-            ' Campus';
+    useEffect(() => {
+        const fetchHousingData = async () => {
+            // Ensure the user is authenticated before fetching
+            if (!user) {
+                setLoading(false);
+                return;
+            }
 
-        const buildingCard: BuildingCard = {
-            id: building.id,
-            name: building.name,
-            image: `/buildings/${building.name
-                .toLowerCase()
-                .replace(/\s+/g, '-')
-                .replace(/-+/g, '-')}.jpg`,
-            description: building.description,
-            floors: building.floors,
+            try {
+                const response = await fetch(
+                    `${process.env.BACKEND_LINK}/api/campus/housing`,
+                    {
+                        credentials: 'include',
+                    }
+                );
+
+                if (!response.ok) {
+                    throw new Error('Failed to fetch housing data');
+                }
+
+                const buildings = (await response.json()) as BuildingDoc[];
+
+                // Organize buildings by campus
+                const organizedData: CampusGroup[] = buildings.reduce(
+                    (acc, building) => {
+                        const campusName =
+                            building.campus.charAt(0).toUpperCase() +
+                            building.campus.slice(1) +
+                            ' Campus';
+
+                        const buildingCard: BuildingCard = {
+                            id: building.id,
+                            name: building.name,
+                            image: `/buildings/${building.name
+                                .toLowerCase()
+                                .replace(/\s+/g, '-')
+                                .replace(/-+/g, '-')}.jpg`,
+                            description: building.description,
+                            floors: building.floors,
+                        };
+
+                        const existingCampus = acc.find(
+                            (c) => c.campus === campusName
+                        );
+                        if (existingCampus) {
+                            existingCampus.buildings.push(buildingCard);
+                        } else {
+                            acc.push({
+                                campus: campusName,
+                                buildings: [buildingCard],
+                            });
+                        }
+
+                        return acc;
+                    },
+                    [] as CampusGroup[]
+                );
+
+                setHousingData(organizedData);
+            } catch (err) {
+                console.error('Error fetching housing data:', err);
+                setError(
+                    'Could not load housing information. Please try again later.'
+                );
+            } finally {
+                setLoading(false);
+            }
         };
 
-        const existingCampus = acc.find((c) => c.campus === campusName);
-        if (existingCampus) {
-            existingCampus.buildings.push(buildingCard);
-        } else {
-            acc.push({
-                campus: campusName,
-                buildings: [buildingCard],
-            });
+        // Only run fetch if auth has loaded and a user exists
+        if (!authLoading) {
+            fetchHousingData();
         }
+    }, [user, authLoading]); // Re-run if auth state changes
 
-        return acc;
-    }, [] as CampusGroup[]);
+    if (authLoading || loading) {
+        return <Loading />;
+    }
+
+    if (!user) {
+        return <LoginRequired />;
+    }
+
+    if (error) {
+        return (
+            <div className="min-h-screen bg-gray-100 text-gray-900">
+                <div className="flex items-center justify-center h-screen text-red-500">
+                    <p>{error}</p>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="min-h-screen bg-gray-100 text-gray-900">
@@ -102,7 +161,7 @@ const HousingPage = async () => {
                                             ...
                                         </p>
                                         <span className="mt-4 inline-block text-blue-600 hover:underline">
-                                            View Details →
+                                            View Details
                                         </span>
                                     </div>
                                 </Link>


### PR DESCRIPTION
## Context
- The frontend was making a call to mongo db this instead calls the backend route to pull the building data
- The appearance and functionality should be the same this is just to remove db calls from the frontend delegating that to the backend

## Describe your changes
- Converted from server component to client component to use useEffect allowing us to fetch data when the page is mounted
- Called backend route /api/campus/housing for buildings rather than mongo db directly 


## Testing

Before 
<img width="1512" height="795" alt="Before" src="https://github.com/user-attachments/assets/38c6aed7-2c59-46b2-9917-db47c93b616d" />

After 
<img width="1512" height="794" alt="After" src="https://github.com/user-attachments/assets/07cfc058-5f7f-45c8-a572-eb9cee7bfe25" />
