### PR TITLE
ASPC 37 - Forum Modal Updates

### DIFF
--- a/backend/src/models/Forum.ts
+++ b/backend/src/models/Forum.ts
@@ -110,7 +110,6 @@ const EventReviewSchema = new Schema<IEventReview>(
         },
         content: {
             type: String,
-            required: true,
             maxlength: 1000,
             trim: true,
         },

--- a/backend/src/models/Forum.ts
+++ b/backend/src/models/Forum.ts
@@ -4,21 +4,6 @@ import mongoose, { Document, Schema } from 'mongoose';
 // ForumEvent Interfaces and Schema
 // ============================================
 
-// Interface for rating subdocument
-interface ICustomRating {
-    question: string;
-    rating: number;
-}
-
-interface IRating {
-    userId: mongoose.Types.ObjectId;
-    isAnonymous: boolean;
-    overall: number;
-    wouldRepeat: number;
-    customRatings: ICustomRating[];
-    createdAt: Date;
-}
-
 // Interface for ForumEvent document
 interface IForumEvent extends Document {
     title: string;
@@ -29,7 +14,6 @@ interface IForumEvent extends Document {
     location: string;
     engageEventId?: string;
     ratingUntil: Date;
-    ratings: IRating[];
     customQuestions: string[];
 }
 
@@ -72,49 +56,6 @@ const ForumEventSchema = new Schema<IForumEvent>(
             type: Date,
             required: true,
         },
-        ratings: [
-            {
-                userId: {
-                    type: mongoose.Schema.Types.ObjectId,
-                    ref: 'SAMLUser',
-                    required: true,
-                },
-                isAnonymous: {
-                    type: Boolean,
-                    default: false,
-                },
-                overall: {
-                    type: Number,
-                    required: true,
-                    min: 1,
-                    max: 5,
-                },
-                wouldRepeat: {
-                    type: Number,
-                    required: true,
-                    min: 1,
-                    max: 5,
-                },
-                customRatings: [
-                    {
-                        question: {
-                            type: String,
-                            required: true,
-                        },
-                        rating: {
-                            type: Number,
-                            required: true,
-                            min: 1,
-                            max: 5,
-                        },
-                    },
-                ],
-                createdAt: {
-                    type: Date,
-                    default: Date.now,
-                },
-            },
-        ],
         customQuestions: [
             {
                 type: String,
@@ -127,68 +68,31 @@ const ForumEventSchema = new Schema<IForumEvent>(
     }
 );
 
-// Instance methods for ForumEvent
-ForumEventSchema.methods.hasUserRated = function (userId: string): boolean {
-    return this.ratings.some(
-        (rating: IRating) => rating.userId.toString() === userId.toString()
-    );
-};
-
-ForumEventSchema.methods.getAverageRatings = function () {
-    if (this.ratings.length === 0) {
-        return {
-            overall: 0,
-            wouldRepeat: 0,
-            customQuestions: {},
-            totalResponses: 0,
-        };
-    }
-
-    const totalResponses = this.ratings.length;
-    let overallSum = 0;
-    let wouldRepeatSum = 0;
-    const customSums: { [key: string]: number } = {};
-
-    this.ratings.forEach((rating: IRating) => {
-        overallSum += rating.overall;
-        wouldRepeatSum += rating.wouldRepeat;
-
-        rating.customRatings.forEach((custom: ICustomRating) => {
-            if (!customSums[custom.question]) {
-                customSums[custom.question] = 0;
-            }
-            customSums[custom.question] += custom.rating;
-        });
-    });
-
-    const customAverages: { [key: string]: number } = {};
-    Object.keys(customSums).forEach((question) => {
-        customAverages[question] = customSums[question] / totalResponses;
-    });
-
-    return {
-        overall: overallSum / totalResponses,
-        wouldRepeat: wouldRepeatSum / totalResponses,
-        customQuestions: customAverages,
-        totalResponses,
-    };
-};
-
 const ForumEvent = mongoose.model<IForumEvent>('ForumEvent', ForumEventSchema);
 
 // ============================================
 // EventComment Interface and Schema
 // ============================================
 
-interface IEventComment extends Document {
+// Interface for rating subdocument
+interface ICustomRating {
+    question: string;
+    rating: number;
+}
+
+interface IEventReview extends Document {
     eventId: mongoose.Types.ObjectId;
     author: mongoose.Types.ObjectId;
     isAnonymous: boolean;
     content: string;
     isHidden: boolean;
+    // Rating fields
+    overall: number;
+    wouldRepeat: number;
+    customRatings: ICustomRating[];
 }
 
-const EventCommentSchema = new Schema<IEventComment>(
+const EventReviewSchema = new Schema<IEventReview>(
     {
         eventId: {
             type: mongoose.Schema.Types.ObjectId,
@@ -214,6 +118,33 @@ const EventCommentSchema = new Schema<IEventComment>(
             type: Boolean,
             default: false,
         },
+        // Rating fields
+        overall: {
+            type: Number,
+            required: true,
+            min: 1,
+            max: 5,
+        },
+        wouldRepeat: {
+            type: Number,
+            required: true,
+            min: 1,
+            max: 5,
+        },
+        customRatings: [
+            {
+                question: {
+                    type: String,
+                    required: true,
+                },
+                rating: {
+                    type: Number,
+                    required: true,
+                    min: 1,
+                    max: 5,
+                },
+            },
+        ],
     },
     {
         timestamps: true,
@@ -221,19 +152,144 @@ const EventCommentSchema = new Schema<IEventComment>(
 );
 
 // Create compound index to ensure one comment per user per event
-EventCommentSchema.index({ eventId: 1, author: 1 }, { unique: true });
+EventReviewSchema.index({ eventId: 1, author: 1 }, { unique: true });
 
-const EventComment = mongoose.model<IEventComment>(
+// Add indexes for aggregation performance
+EventReviewSchema.index({ eventId: 1, overall: 1 });
+EventReviewSchema.index({ eventId: 1, wouldRepeat: 1 });
+
+// ============================================
+// Static Methods for Rating Aggregation
+// ============================================
+
+EventReviewSchema.statics.hasUserRated = async function (
+    eventId: string | mongoose.Types.ObjectId,
+    userId: string | mongoose.Types.ObjectId
+): Promise<boolean> {
+    const comment = await this.findOne({ eventId, author: userId });
+    return comment !== null;
+};
+
+EventReviewSchema.statics.getAverageRatings = async function (
+    eventId: string | mongoose.Types.ObjectId
+) {
+    const result = await this.aggregate([
+        {
+            $match: {
+                eventId: new mongoose.Types.ObjectId(eventId.toString()),
+                isHidden: false, 
+            },
+        },
+        {
+            $facet: {
+                // Calculate overall and wouldRepeat averages
+                basicStats: [
+                    {
+                        $group: {
+                            _id: null,
+                            overall: { $avg: '$overall' },
+                            wouldRepeat: { $avg: '$wouldRepeat' },
+                            totalResponses: { $sum: 1 },
+                        },
+                    },
+                ],
+                // Calculate custom question averages
+                customStats: [
+                    { $unwind: '$customRatings' },
+                    {
+                        $group: {
+                            _id: '$customRatings.question',
+                            average: { $avg: '$customRatings.rating' },
+                        },
+                    },
+                ],
+            },
+        },
+    ]);
+
+    // Parse results
+    const basicStats = result[0]?.basicStats[0] || {
+        overall: 0,
+        wouldRepeat: 0,
+        totalResponses: 0,
+    };
+
+    const customQuestions: { [key: string]: number } = {};
+    if (result[0]?.customStats) {
+        result[0].customStats.forEach(
+            (stat: { _id: string; average: number }) => {
+                customQuestions[stat._id] = stat.average;
+            }
+        );
+    }
+
+    return {
+        overall: basicStats.overall || 0,
+        wouldRepeat: basicStats.wouldRepeat || 0,
+        customQuestions,
+        totalResponses: basicStats.totalResponses || 0,
+    };
+};
+
+// Optional: Get all ratings for an event (with pagination support)
+EventReviewSchema.statics.getRatingsForEvent = async function (
+    eventId: string | mongoose.Types.ObjectId,
+    options: { skip?: number; limit?: number; includeHidden?: boolean } = {}
+) {
+    const { skip = 0, limit = 50, includeHidden = false } = options;
+
+    const query: any = { eventId };
+    if (!includeHidden) {
+        query.isHidden = false;
+    }
+
+    return this.find(query)
+        .populate('author', 'name email') // Adjust fields as needed
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+};
+
+const EventComment = mongoose.model<IEventReview>(
     'EventComment',
-    EventCommentSchema
+    EventReviewSchema
 );
+
+// ============================================
+// TypeScript Interface Extensions for Statics
+// ============================================
+
+interface IEventCommentModel extends mongoose.Model<IEventReview> {
+    hasUserRated(
+        eventId: string | mongoose.Types.ObjectId,
+        userId: string | mongoose.Types.ObjectId
+    ): Promise<boolean>;
+    
+    getAverageRatings(
+        eventId: string | mongoose.Types.ObjectId
+    ): Promise<{
+        overall: number;
+        wouldRepeat: number;
+        customQuestions: { [key: string]: number };
+        totalResponses: number;
+    }>;
+    
+    getRatingsForEvent(
+        eventId: string | mongoose.Types.ObjectId,
+        options?: { skip?: number; limit?: number; includeHidden?: boolean }
+    ): Promise<any[]>;
+}
 
 // Export all models and interfaces
 export {
     ForumEvent,
-    EventComment,
+    EventComment as EventCommentModel,
     IForumEvent,
-    IEventComment,
-    IRating,
+    IEventReview,
+    IEventCommentModel,
     ICustomRating,
 };
+
+// Re-export with proper typing
+export default EventComment as IEventCommentModel;


### PR DESCRIPTION
## Context

Before we had it that ratings were embedded within the EventForum, but that caused problems for user-specific information, such as getting a user's past ratings (lots of unnecessary joins) and checking if a user had already commented (linear scan). We want to find a way to keep an effective way to process summary statistics of the different ratings, while keeping a scalable way to handle comparisons with user data. Moving ratings to the previous EventsComment modal allows us to easily groupby and aggregate based on eventId or userID.

## Describe your changes

- Moved ratings from ForumEvent to EventComment (Renamed EventReviews): Removed the embedded ratings array from ForumEvent and added overall, wouldRepeat, and customRatings fields directly to EventComment schema
- Replaced instance methods with static aggregation methods: Converted hasUserRated() and getAverageRatings() from ForumEvent instance methods (which iterated arrays in JavaScript) to EventComment static methods that use MongoDB aggregation pipelines with $match, $group, and $facet operators
- Added performance indexes: Created compound indexes on (eventId, author) for uniqueness, plus (eventId, overall) and (eventId, wouldRepeat) to optimize aggregation query performance
- Changed data access pattern: Instead of one query loading the event with all embedded ratings, now requires two queries - one for event details and one aggregation pipeline for rating statistics, but only transfers computed averages rather than all raw rating data

## Testing

Test through backend routes later.
