### PR TITLE
Script for Testing Populating StudentballotInfo

### DIFF
--- a/backend/src/scripts/populateStudentBallotInfo.ts
+++ b/backend/src/scripts/populateStudentBallotInfo.ts
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+import { StudentBallotInfo } from '../models/Voting';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const ELECTION_ID = '';
+const EMAILS: string[] = [];
+
+const MONGO_URI = process.env.MONGODB_TEST_URI || '';
+async function populateStudentBallotInfo() {
+    if (!ELECTION_ID) throw new Error('ELECTION_ID is required');
+    if (EMAILS.length === 0) throw new Error('EMAILS array is empty');
+
+    await mongoose.connect(MONGO_URI);
+    console.log('Connected to MongoDB');
+
+    const campusReps: ('north' | 'south')[] = ['north', 'south'];
+    const years = [1, 2, 3, 4];
+
+    const docs = EMAILS.map((email, i) => ({
+        electionId: new mongoose.Types.ObjectId(ELECTION_ID),
+        email,
+        campusRep: campusReps[i % campusReps.length],
+        year: years[i % years.length],
+        hasVoted: false,
+    }));
+
+    const result = await StudentBallotInfo.insertMany(docs, { ordered: false });
+    console.log(
+        `Successfully inserted ${result.length} StudentBallotInfo documents`
+    );
+
+    await mongoose.disconnect();
+    console.log('Disconnected from MongoDB');
+}
+
+populateStudentBallotInfo().catch((err) => {
+    console.error('Error populating StudentBallotInfo:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Context

- voting system uses a StudentBallotInfo collection to track voter eligibility and ballot metadata per election
- New elections require pre-populating this collection with a list of eligible student emails before voting can begin
- THIS IS USED ONLY FOR SENATE PRESENTATION SIMULATION OF VOTING PROCESS

## Describe your changes

- Added populateStudentBallotInfo.ts seed script that accepts a hardcoded election ID and email list
- Evenly distributes campusRep (north/south) and year (1–4) across students using index-based modulo assignment
- Uses insertMany with ordered: false to gracefully skip duplicates without aborting the batch

## Later

- Change script so it run for the entire student body and their appropriate year and campus 


## Testing

<img width="794" height="610" alt="image" src="https://github.com/user-attachments/assets/68512e0b-7beb-4db4-a354-75f4eed7bf05" />
<img width="593" height="104" alt="image" src="https://github.com/user-attachments/assets/eacf72d9-0af2-4764-b362-22bb03524223" />
