### PR TITLE
FIX: Improve load time of housing review pages

### DIFF
--- a/backend/src/routes/HousingRoutes.ts
+++ b/backend/src/routes/HousingRoutes.ts
@@ -1,16 +1,16 @@
 import express, { Request, Response } from 'express';
-import multer from 'multer';
-import {
-    HousingBuildings,
-    HousingRooms,
-    HousingReviews,
-} from '../models/Housing';
-import { housingReviewPictures } from '../server';
 import { ObjectId } from 'mongodb';
+import multer from 'multer';
 import {
     isAuthenticated,
     isHousingReviewOwner,
 } from '../middleware/authMiddleware';
+import {
+    HousingBuildings,
+    HousingReviews,
+    HousingRooms,
+} from '../models/Housing';
+import { housingReviewPictures } from '../server';
 
 const router = express.Router();
 
@@ -542,6 +542,69 @@ router.get(
             });
         } catch (error) {
             res.status(400).json({ message: 'Invalid profile picture ID' });
+        }
+    }
+);
+
+/**
+ * @route   GET /api/campus/housing/:building/ratings
+ * @desc    Get ratings for all rooms in a building
+ * @access  isAuthenticated
+ */
+router.get(
+    '/:building/ratings',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const buildingId = parseInt(req.params.building, 10);
+            if (isNaN(buildingId)) {
+                res.status(400).json({ message: 'Invalid building ID format' });
+                return;
+            }
+
+            // Get all rooms for the building
+            const rooms = await HousingRooms.find({
+                housing_building_id: buildingId,
+            });
+            if (!rooms || rooms.length === 0) {
+                res.json({});
+                return;
+            }
+
+            const roomIds = rooms.map((r) => r.id);
+
+            // Fetch all reviews for all rooms in one query
+            const allReviews = await HousingReviews.find({
+                housing_room_id: { $in: roomIds },
+            });
+
+            // Group reviews by room id and calculate averages
+            const calcAverage = (arr: number[]) =>
+                arr.length > 0
+                    ? arr.reduce((sum, val) => sum + val, 0) / arr.length
+                    : 0;
+
+            const ratingsMap: Record<
+                number,
+                { overallAverage: number; reviewCount: number }
+            > = {};
+
+            for (const room of rooms) {
+                const roomReviews = allReviews.filter(
+                    (r) => r.housing_room_id === room.id
+                );
+                const overallRatings = roomReviews
+                    .map((r) => r.overall_rating)
+                    .filter(Boolean) as number[];
+                ratingsMap[room.id] = {
+                    overallAverage: calcAverage(overallRatings),
+                    reviewCount: roomReviews.length,
+                };
+            }
+
+            res.json(ratingsMap);
+        } catch (error) {
+            res.status(500).json({ message: 'Server error' });
         }
     }
 );

--- a/frontend/src/app/campus/housing/[id]/[room]/page.tsx
+++ b/frontend/src/app/campus/housing/[id]/[room]/page.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
-import { useParams, useRouter } from 'next/navigation';
 import Loading from '@/components/Loading';
-import { Review, RoomWithReviews } from '@/types';
-import Image from 'next/image';
-import { useAuth } from '@/hooks/useAuth';
 import LoginRequired from '@/components/LoginRequired';
+import { PictureModal, ReviewForm } from '@/components/housing/Reviews';
 import { StarRating, getRoomOccupancyType } from '@/components/housing/Rooms';
-import { ReviewForm, PictureModal } from '@/components/housing/Reviews';
+import { useAuth } from '@/hooks/useAuth';
+import { Review, RoomWithReviews } from '@/types';
 import { FormattedReviewText } from '@/utils/textFormatting';
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 
 const RoomPage = () => {
     const params = useParams();
@@ -46,40 +46,37 @@ const RoomPage = () => {
             try {
                 setLoading(true);
 
-                // Fetch building data
-                const buildingResponse = await fetch(
-                    `${process.env.BACKEND_LINK}/api/campus/housing/${id}`,
-                    {
-                        credentials: 'include',
-                    }
-                );
+                const [buildingResponse, reviewsResponse] = await Promise.all([
+                    fetch(
+                        `${process.env.BACKEND_LINK}/api/campus/housing/${id}`,
+                        {
+                            credentials: 'include',
+                        }
+                    ),
+                    fetch(
+                        `${process.env.BACKEND_LINK}/api/campus/housing/${id}/${room}/reviews`,
+                        {
+                            credentials: 'include',
+                        }
+                    ),
+                ]);
 
-                if (!buildingResponse.ok) {
+                if (!buildingResponse.ok)
                     throw new Error(
-                        `Failed to fetch building name: ${buildingResponse.status}`
+                        `Failed to fetch building: ${buildingResponse.status}`
                     );
-                }
+                if (!reviewsResponse.ok)
+                    throw new Error(
+                        `Failed to fetch reviews: ${reviewsResponse.status}`
+                    );
 
-                const buildingData = await buildingResponse.json();
+                const [buildingData, reviewsData] = await Promise.all([
+                    buildingResponse.json(),
+                    reviewsResponse.json(),
+                ]);
+
                 setBuildingName(buildingData.name);
-
-                // Fetch reviews
-                const reviews = await fetch(
-                    `${process.env.BACKEND_LINK}/api/campus/housing/${id}/${room}/reviews`,
-                    {
-                        credentials: 'include',
-                    }
-                );
-
-                if (!reviews.ok) {
-                    throw new Error(
-                        `Failed to fetch reviews: ${reviews.status}`
-                    );
-                }
-
-                const data = await reviews.json();
-
-                setRoomReviews(data);
+                setRoomReviews(reviewsData);
             } catch (error) {
                 console.error('Error fetching room reviews:', error);
             } finally {

--- a/frontend/src/app/campus/housing/[id]/page.tsx
+++ b/frontend/src/app/campus/housing/[id]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
 import Loading from '@/components/Loading';
-import { Room, Building } from '@/types';
-import { useAuth } from '@/hooks/useAuth';
 import LoginRequired from '@/components/LoginRequired';
 import { RoomCard } from '@/components/housing/Rooms';
+import { useAuth } from '@/hooks/useAuth';
+import { Building, Room } from '@/types';
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function DynamicRooms() {
     const params = useParams();
@@ -22,63 +22,35 @@ export default function DynamicRooms() {
     const { user, loading: authLoading } = useAuth();
     const [showFloorPlans, setShowFloorPlans] = useState(false);
 
-    // Fetch room ratings for all rooms
-    const fetchRoomRatings = async (roomsList: Room[]) => {
-        const roomsWithRatings = await Promise.all(
-            roomsList.map(async (room) => {
-                try {
-                    const response = await fetch(
-                        `${process.env.BACKEND_LINK}/api/campus/housing/${room.id}/reviews`,
-                        {
-                            credentials: 'include',
-                        }
-                    );
-
-                    if (response.ok) {
-                        const data = await response.json();
-                        return {
-                            ...room,
-                            averageRating: data.averages?.overallAverage || 0,
-                            reviewCount: data.averages?.reviewCount || 0,
-                        };
-                    }
-
-                    return room;
-                } catch (error) {
-                    console.error(
-                        `Error fetching ratings for room ${room.id}:`,
-                        error
-                    );
-                    return room;
-                }
-            })
-        );
-
-        return roomsWithRatings;
-    };
-
     useEffect(() => {
         const fetchRooms = async () => {
             try {
                 setLoading(true);
                 setBuildingNotFound(false);
 
-                // Validate building parameter is a number
                 const buildingId = Number(id);
-
                 if (isNaN(buildingId)) {
                     setBuildingNotFound(true);
                     setError('Invalid building ID format');
                     return;
                 }
 
-                // First fetch building info to check if it exists
-                const buildingResponse = await fetch(
-                    `${process.env.BACKEND_LINK}/api/campus/housing/${buildingId}`,
-                    {
-                        credentials: 'include',
-                    }
-                );
+                // 1. Fetch building + rooms in parallel
+                const [buildingResponse, roomsResponse, ratingsResponse] =
+                    await Promise.all([
+                        fetch(
+                            `${process.env.BACKEND_LINK}/api/campus/housing/${buildingId}`,
+                            { credentials: 'include' }
+                        ),
+                        fetch(
+                            `${process.env.BACKEND_LINK}/api/campus/housing/${buildingId}/rooms`,
+                            { credentials: 'include' }
+                        ),
+                        fetch(
+                            `${process.env.BACKEND_LINK}/api/campus/housing/${buildingId}/ratings`,
+                            { credentials: 'include' }
+                        ),
+                    ]);
 
                 if (!buildingResponse.ok) {
                     if (buildingResponse.status === 404) {
@@ -92,7 +64,28 @@ export default function DynamicRooms() {
                     return;
                 }
 
-                const buildingData = await buildingResponse.json();
+                if (!roomsResponse.ok) {
+                    setError('Failed to load rooms. Please try again later.');
+                }
+
+                const [buildingData, roomsData, ratingsMap] = await Promise.all(
+                    [
+                        buildingResponse.json(),
+                        roomsResponse.ok
+                            ? roomsResponse.json()
+                            : ([] as Room[]),
+                        ratingsResponse.ok
+                            ? ratingsResponse.json()
+                            : ({} as Record<
+                                  number,
+                                  {
+                                      overallAverage: number;
+                                      reviewCount: number;
+                                  }
+                              >),
+                    ]
+                );
+
                 setBuilding(buildingData);
                 setSafeName(
                     buildingData.name
@@ -101,33 +94,13 @@ export default function DynamicRooms() {
                         .replace(/-+/g, '-')
                 );
 
-                // Now fetch rooms for this building
-                const response = await fetch(
-                    `${process.env.BACKEND_LINK}/api/campus/housing/${buildingId}/rooms`,
-                    {
-                        credentials: 'include',
-                    }
+                setRooms(
+                    roomsData.map((room: Room) => ({
+                        ...room,
+                        averageRating: ratingsMap[room.id]?.overallAverage || 0,
+                        reviewCount: ratingsMap[room.id]?.reviewCount || 0,
+                    }))
                 );
-
-                if (!response.ok) {
-                    if (response.status === 404) {
-                        // No rooms but building exists
-                        setRooms([]);
-                    } else {
-                        throw new Error(
-                            `Failed to fetch rooms: ${response.status}`
-                        );
-                    }
-                    return;
-                }
-
-                const data = await response.json();
-
-                const roomsData: Room[] = data || [];
-
-                // Get ratings for all rooms
-                const roomsWithRatings = await fetchRoomRatings(roomsData);
-                setRooms(roomsWithRatings);
             } catch (error) {
                 console.error('Error fetching rooms:', error);
                 setError('Failed to load rooms. Please try again later.');
@@ -161,6 +134,15 @@ export default function DynamicRooms() {
                         </p>
                         <p className="text-gray-600 mt-2">Error: {error}</p>
                     </div>
+                </div>
+            </div>
+        );
+    }
+    if (error && !buildingNotFound) {
+        return (
+            <div className="min-h-screen bg-gray-100 text-gray-900">
+                <div className="flex items-center justify-center h-screen text-red-500">
+                    <p>{error}</p>
                 </div>
             </div>
         );

--- a/frontend/src/components/housing/Rooms.tsx
+++ b/frontend/src/components/housing/Rooms.tsx
@@ -1,7 +1,6 @@
 'use client';
-import React from 'react';
-import Link from 'next/link';
 import { RoomCardProps } from '@/types';
+import Link from 'next/link';
 
 export const StarRating = ({ rating }: { rating: number }) => {
     const totalStars = 5;
@@ -76,6 +75,7 @@ export const RoomCard = ({ buildingName, room }: RoomCardProps) => {
 
             <Link
                 href={`/campus/housing/${room.housing_building_id}/${room.room_number}`}
+                prefetch={false}
             >
                 <button className="px-6 py-2 border border-blue-300 text-blue-500 rounded-md hover:bg-blue-50 transition-colors">
                     View Reviews


### PR DESCRIPTION
## Context

Housing pages were taking a long time to load. This was for both the pages showing all rooms in a buildings and pages showing all reviews for a room.

This was due to Next.js prefetching <Link> components. On the main housing page which displays buildings, each building card was prefetching the building data, which in turn was prefetching room and review data, each of which requires 2 database calls. 



## Describe your changes

To fix this, we first set `prefetch={false}` for the <Link> components.

We were also making one database call for each room in order to calculate the ratings for display on the RoomCard. Now, we only make one call to get all reviews, then calculate the average ratings by filtering for reviews that belong to a given room.

## Testing

Before

https://github.com/user-attachments/assets/cc865ff9-a939-4f12-88d9-29bc9cbb3b03

After

https://github.com/user-attachments/assets/a400887a-57a7-4500-86cf-350b2b8baa11
