### PR TITLE
Fix/no review user email in frontend

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -200,8 +200,8 @@ export const isEventReviewOwner = async (
         return;
     }
 
-    // Compare MongoDB ObjectIds (convert to string for comparison)
-    if (review.author.toString() !== user._id) {
+    // Compare MongoDB ObjectIds (convert both to string for comparison)
+    if (review.author.toString() !== String(user._id)) {
         res.status(403).json({
             message: 'You are not authorized to modify this review',
         });

--- a/backend/src/routes/CoursesRoutes.ts
+++ b/backend/src/routes/CoursesRoutes.ts
@@ -609,9 +609,16 @@ router.get(
 
             const reviews = await CourseReviews.find({ course_id: courseId })
                 .sort({ updatedAt: -1 }) // -1 for descending order (newest first)
+                .lean()
                 .exec();
 
-            res.json(reviews);
+            const sessionEmail = req.session.user!.email;
+            const safeReviews = reviews.map(({ user_email, ...fields }) => ({
+                ...fields,
+                isOwner: user_email === sessionEmail,
+            }));
+
+            res.json(safeReviews);
         } catch (err) {
             console.error(err);
             res.status(500).json({ message: 'Server error' });

--- a/backend/src/routes/ForumRoutes.ts
+++ b/backend/src/routes/ForumRoutes.ts
@@ -121,7 +121,29 @@ router.get(
                 return;
             }
 
-            res.json(reviews);
+            const azureId = req.session.user!.id;
+            const currentUser = await SAMLUser.findOne({ id: azureId });
+
+            const safeReviews = reviews.map((review) => {
+                const doc = review.toObject();
+                const authorId =
+                    doc.author && typeof doc.author === 'object'
+                        ? (doc.author as any)._id?.toString()
+                        : null;
+                const isOwner =
+                    !!currentUser &&
+                    !!authorId &&
+                    authorId === String(currentUser._id);
+                return {
+                    ...doc,
+                    // Strip author identity from anonymous reviews so the name
+                    // cannot be recovered from the network response
+                    author: doc.isAnonymous ? null : doc.author,
+                    isOwner,
+                };
+            });
+
+            res.json(safeReviews);
         } catch (error) {
             res.status(500).json({ message: 'Server error' });
         }

--- a/backend/src/routes/HousingRoutes.ts
+++ b/backend/src/routes/HousingRoutes.ts
@@ -133,7 +133,13 @@ router.get(
             // Get all reviews for the room
             const reviews = await HousingReviews.find({
                 housing_room_id: roomId,
-            });
+            }).lean();
+
+            const sessionEmail = req.session.user!.email;
+            const safeReviews = reviews.map(({ user_email, ...fields }) => ({
+                ...fields,
+                isOwner: user_email === sessionEmail,
+            }));
 
             // Calculate average ratings
             if (reviews.length > 0) {
@@ -166,7 +172,7 @@ router.get(
                 // Return reviews and averages as well as the room data itself
                 res.json({
                     room: roomData,
-                    reviews: reviews,
+                    reviews: safeReviews,
                     averages: averages,
                 });
                 return;
@@ -175,7 +181,7 @@ router.get(
             // Return reviews (even if empty)
             res.json({
                 room: roomData,
-                reviews: reviews,
+                reviews: safeReviews,
                 averages: {
                     overallAverage: 0,
                     quietAverage: 0,
@@ -223,7 +229,13 @@ router.get(
             // Get all reviews for the room using room id
             const reviews = await HousingReviews.find({
                 housing_room_id: roomData.id,
-            });
+            }).lean();
+
+            const sessionEmail = req.session.user!.email;
+            const safeReviews = reviews.map(({ user_email, ...fields }) => ({
+                ...fields,
+                isOwner: user_email === sessionEmail,
+            }));
 
             // Calculate average ratings
             if (reviews.length > 0) {
@@ -256,7 +268,7 @@ router.get(
                 // Return reviews and averages as well as the room data itself
                 res.json({
                     room: roomData,
-                    reviews: reviews,
+                    reviews: safeReviews,
                     averages: averages,
                 });
                 return;
@@ -265,7 +277,7 @@ router.get(
             // Return reviews (even if empty)
             res.json({
                 room: roomData,
-                reviews: reviews,
+                reviews: safeReviews,
                 averages: {
                     overallAverage: 0,
                     quietAverage: 0,

--- a/backend/src/routes/InstructorsRoutes.ts
+++ b/backend/src/routes/InstructorsRoutes.ts
@@ -204,9 +204,18 @@ router.get('/:id/reviews', async (req: Request, res: Response) => {
         // Get all reviews for this instructor
         const reviews = await CourseReviews.find({
             instructor_id: instructorId,
-        }).sort({ updatedAt: -1 });
+        })
+            .sort({ updatedAt: -1 })
+            .lean()
+            .exec();
 
-        res.json(reviews);
+        const sessionEmail = req.session.user!.email;
+        const safeReviews = reviews.map(({ user_email, ...fields }) => ({
+            ...fields,
+            isOwner: user_email === sessionEmail,
+        }));
+
+        res.json(safeReviews);
     } catch (err) {
         console.error(err);
         res.status(500).json({ message: 'Server error' });

--- a/backend/src/routes/InstructorsRoutes.ts
+++ b/backend/src/routes/InstructorsRoutes.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, Router } from 'express';
 import { Instructors } from '../models/People';
 import { CourseReviews } from '../models/Courses';
+import { isAuthenticated } from '../middleware/authMiddleware';
 
 const router: Router = express.Router();
 
@@ -182,45 +183,51 @@ router.put('/:id', async (req: Request, res: Response) => {
  * @desc    Get all reviews for a specific instructor
  * @access  Public
  */
-router.get('/:id/reviews', async (req: Request, res: Response) => {
-    try {
-        const instructorId = parseInt(req.params.id);
+router.get(
+    '/:id/reviews',
+    isAuthenticated,
+    async (req: Request, res: Response) => {
+        try {
+            const instructorId = parseInt(req.params.id);
 
-        // Check if conversion is valid
-        if (isNaN(instructorId)) {
-            res.status(400).json({ message: 'Invalid instructor ID format' });
-            return;
+            // Check if conversion is valid
+            if (isNaN(instructorId)) {
+                res.status(400).json({
+                    message: 'Invalid instructor ID format',
+                });
+                return;
+            }
+
+            // Verify instructor exists
+            const instructor = await Instructors.findOne({
+                id: instructorId,
+            });
+
+            if (!instructor) {
+                res.status(404).json({ message: 'Instructor not found' });
+                return;
+            }
+            // Get all reviews for this instructor
+            const reviews = await CourseReviews.find({
+                instructor_id: instructorId,
+            })
+                .sort({ updatedAt: -1 })
+                .lean()
+                .exec();
+
+            const sessionEmail = req.session.user!.email;
+            const safeReviews = reviews.map(({ user_email, ...fields }) => ({
+                ...fields,
+                isOwner: user_email === sessionEmail,
+            }));
+
+            res.json(safeReviews);
+        } catch (err) {
+            console.error(err);
+            res.status(500).json({ message: 'Server error' });
         }
-
-        // Verify instructor exists
-        const instructor = await Instructors.findOne({
-            id: instructorId,
-        });
-
-        if (!instructor) {
-            res.status(404).json({ message: 'Instructor not found' });
-            return;
-        }
-        // Get all reviews for this instructor
-        const reviews = await CourseReviews.find({
-            instructor_id: instructorId,
-        })
-            .sort({ updatedAt: -1 })
-            .lean()
-            .exec();
-
-        const sessionEmail = req.session.user!.email;
-        const safeReviews = reviews.map(({ user_email, ...fields }) => ({
-            ...fields,
-            isOwner: user_email === sessionEmail,
-        }));
-
-        res.json(safeReviews);
-    } catch (err) {
-        console.error(err);
-        res.status(500).json({ message: 'Server error' });
     }
-});
+);
 
 /**
  * @route   GET /api/instructors/:id/courses

--- a/frontend/src/app/campus/courses/[id]/page.tsx
+++ b/frontend/src/app/campus/courses/[id]/page.tsx
@@ -583,8 +583,7 @@ const CoursePage = () => {
                                                         </span>
                                                     </div>
 
-                                                    {user.email ==
-                                                        review.user_email && (
+                                                    {review.isOwner && (
                                                         <div className="flex p-2 gap-4">
                                                             <button
                                                                 className="bg-blue-500 text-white text-m px-4 rounded-md hover:bg-blue-600"

--- a/frontend/src/app/campus/housing/[id]/[room]/page.tsx
+++ b/frontend/src/app/campus/housing/[id]/[room]/page.tsx
@@ -294,8 +294,7 @@ const RoomPage = () => {
                                                     </span>
                                                 </div>
 
-                                                {user.email ==
-                                                    review.user_email && (
+                                                {review.isOwner && (
                                                     <div className="flex p-2 gap-4">
                                                         <button
                                                             className="bg-blue-500 text-white text-m px-4 rounded-md hover:bg-blue-600"

--- a/frontend/src/app/campus/instructors/[id]/page.tsx
+++ b/frontend/src/app/campus/instructors/[id]/page.tsx
@@ -449,8 +449,7 @@ const InstructorPage = (): JSX.Element => {
                                                     </span>
                                                 </div>
 
-                                                {user.email ===
-                                                    review.user_email && (
+                                                {review.isOwner && (
                                                     <div className="flex p-2 gap-4">
                                                         <button
                                                             className="bg-blue-500 text-white text-m px-4 rounded-md hover:bg-blue-600"

--- a/frontend/src/app/dashboard/events/[id]/page.tsx
+++ b/frontend/src/app/dashboard/events/[id]/page.tsx
@@ -47,6 +47,7 @@ interface EventReview {
               firstName: string;
               lastName: string;
           };
+    isOwner: boolean;
     isAnonymous: boolean;
     content?: string;
     overall: number;
@@ -135,16 +136,7 @@ const EventDetailPage = () => {
                     setReviews(reviewsData);
 
                     // Check if user has already reviewed
-                    if (user) {
-                        const userReview = reviewsData.find((r) => {
-                            const authorEmail =
-                                typeof r.author === 'string'
-                                    ? r.author
-                                    : r.author?.email;
-                            return authorEmail === user.email;
-                        });
-                        setHasUserReviewed(!!userReview);
-                    }
+                    setHasUserReviewed(reviewsData.some((r) => r.isOwner));
                 }
             } catch (error) {
                 console.error('Server error', error);

--- a/frontend/src/app/open-forum/[id]/page.tsx
+++ b/frontend/src/app/open-forum/[id]/page.tsx
@@ -73,14 +73,6 @@ const EventDetailsPage = () => {
         window.location.reload();
     };
 
-    // Helper function to get author ID
-    const getAuthorId = (author: string | User): string => {
-        if (typeof author === 'string') {
-            return author;
-        }
-        return author._id || author.id;
-    };
-
     // Helper function to get author display name
     const getAuthorDisplay = (author: string | User): string => {
         if (typeof author === 'string') {
@@ -449,16 +441,13 @@ const EventDetailsPage = () => {
                                 </h2>
                                 {eventDetails.reviews.length > 0 ? (
                                     eventDetails.reviews.map((rating) => {
-                                        const authorId = getAuthorId(
-                                            rating.author
-                                        );
-                                        const authorName = getAuthorDisplay(
-                                            rating.author
-                                        );
-                                        const isAuthor =
-                                            user._id === authorId ||
-                                            user.id === authorId;
-
+                                        let authorName = 'Cecil';
+                                        if (!rating?.isAnonymous) {
+                                            authorName = getAuthorDisplay(
+                                                rating.author
+                                            );
+                                        }
+                                        const isAuthor = rating.isOwner;
                                         return (
                                             <div
                                                 key={rating._id}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,7 +72,7 @@ export interface Review {
     temperature_rating?: number;
     comments?: string;
     housing_room_id: number;
-    user_email: string;
+    isOwner: boolean;
     pictures?: string[];
     createdAt: Date;
     updatedAt: Date;
@@ -140,7 +140,7 @@ export type CourseReview = {
     comments?: string;
     course_id: number;
     instructor_id: number;
-    user_email?: string;
+    isOwner?: boolean;
     createdAt?: Date;
     updatedAt?: Date;
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -209,6 +209,7 @@ export interface EventReview {
     eventId: string;
     author: string | User;
     isAnonymous: boolean;
+    isOwner: boolean;
     content: string;
     isHidden: boolean;
     overall: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -140,7 +140,7 @@ export type CourseReview = {
     comments?: string;
     course_id: number;
     instructor_id: number;
-    isOwner?: boolean;
+    isOwner: boolean;
     createdAt?: Date;
     updatedAt?: Date;
 };


### PR DESCRIPTION
## Context
-[ JIRA ASPC 83](https://aspcsoftware.atlassian.net/browse/ASPC-83)
- Review GET endpoints were returning user_email / populated author.email in responses, allowing any           
  authenticated user to see other reviewers' email addresses via browser DevTools                                
  - Ownership is now determined server-side; the API returns an isOwner: boolean flag instead                    
  - Anonymous forum reviews no longer expose the author's name in the response at all 

## Describe your changes

  Backend                                                                                                        
  
  - CoursesRoutes.ts, InstructorsRoutes.ts: Course review GET endpoints now use .lean(), strip user_email from   
  each document, and replace it with isOwner computed from req.session.user.email
  - HousingRoutes.ts: Same treatment on both housing review GET endpoints (/:room/reviews and                    
  /:buildingId/:roomNumber/reviews)                                                                              
  - ForumRoutes.ts: Event review GET endpoint drops email from .populate('author', ...), resolves the current
  user's MongoDB _id from the session, adds isOwner per review, and sets author: null for anonymous reviews so   
  the author's name cannot be recovered from the network response
  - authMiddleware.ts: Fixes a pre-existing bug in isEventReviewOwner where review.author.toString() !== user._id
   was always true because user._id was never stringified — edit/delete of event reviews was broken for all users
  
  Frontend                                                                                                       
                  
  - types.ts: Review.user_email → isOwner: boolean, CourseReview.user_email? → isOwner?, EventReview gains       
  isOwner: boolean; adds EventReviewAuthor interface (no email field)
  - courses/[id]/page.tsx, housing/[id]/[room]/page.tsx, instructors/[id]/page.tsx: Replace user.email ===       
  review.user_email comparisons with review.isOwner                                                              
  - open-forum/[id]/page.tsx: Replace getAuthorId + _id comparison with rating.isOwner; getAuthorDisplay no
  longer accepts or uses email                                                                                   
  - dashboard/events/[id]/page.tsx: hasUserReviewed now set via reviews.some(r => r.isOwner) instead of matching
  author.email to user.email                                                                                     
                  
  Security model                                                                                                 
                  
  Ownership checks for PATCH/DELETE (in isCourseReviewOwner, isHousingReviewOwner, isEventReviewOwner) are       
  unchanged — they compare session data against the database and were never client-influenced. The isOwner flag
  in GET responses is for UI only; the backend enforces actual authorization independently. 

## Testing
No automated tests exist for these routes yet. Manual test plan:                                               
                  
  As review owner                                                                                                
  - Course review: Edit and Delete buttons appear on your own review; network response contains isOwner: true and
   no user_email field                                                                                           
  - Housing review: same as above
  - Instructor page: Edit and Delete buttons appear on your own course review                                    
  - Event review (open-forum): Edit and Delete buttons appear; event review edit/delete requests succeed (this
  was broken before due to the ObjectId comparison bug)                                                          
  - Event review (dashboard): "Add new rating" button is hidden after you've submitted a review                  
                                                                                                                 
  As a different user                                                                                            
  - Course/housing/instructor reviews: Edit and Delete buttons are hidden; network response contains isOwner:    
  false and no user_email field                                                                                  
  - Event review edit/delete requests return 403                                                                 
                                                                                                                 
  Anonymous event reviews
  - Anonymous review shows "Anonymous Review" in the UI with no author name                                      
  - Network response for an anonymous review has author: null — no name recoverable via DevTools                 
  - If you submitted the anonymous review, your own review still shows the "(Your review)" badge and Edit/Delete 
  buttons                                                                                                        
                                                                                                                 
  DevTools check (core regression test)                                                                          
  - Open Network tab, load any reviews page, inspect the JSON response — confirm no user_email, no email field   
  anywhere in the review objects