### PR TITLE
Fix/instructor bugs

### DIFF
--- a/backend/src/routes/CoursesRoutes.ts
+++ b/backend/src/routes/CoursesRoutes.ts
@@ -885,6 +885,22 @@ router.get(
                         seen.add(doc.id);
                     }
                 }
+                // Supplement with legacy instructor_id docs not already covered by
+                // the cxid lookup. This ensures the frontend's instructorById fallback
+                // works for reviews that pre-date the CxID migration or reference a
+                // duplicate instructor doc (e.g. "Carlson, Kevin David" vs "Carlson, Kevin").
+                const legacyIds = course.all_instructor_ids ?? [];
+                if (legacyIds.length > 0) {
+                    const legacyFound = await Instructors.find({
+                        id: { $in: legacyIds },
+                    }).lean();
+                    for (const leg of legacyFound) {
+                        if (!seen.has(leg.id)) {
+                            ordered.push(leg);
+                            seen.add(leg.id);
+                        }
+                    }
+                }
                 instructors = ordered;
             } else if (pageKeys.length > 0) {
                 const found = await Instructors.find({

--- a/frontend/src/app/campus/courses/[id]/page.tsx
+++ b/frontend/src/app/campus/courses/[id]/page.tsx
@@ -163,12 +163,13 @@ const CoursePage = () => {
                 const courseData: Course = await coursesResponse.json();
                 setCourseName(courseData.name);
 
-                // Fetch instructors
+                // Fetch instructors — use high limit so all historical instructors
+                // are available for review lookups (instructorByCxid / instructorById)
                 const instructorResponse = await fetch(
-                    `${process.env.BACKEND_LINK}/api/courses/${courseData.id}/instructors`,
+                    `${process.env.BACKEND_LINK}/api/courses/${courseData.id}/instructors?limit=500`,
                     {
                         method: 'GET',
-                        credentials: 'include', // This allows sending cookies for session identification
+                        credentials: 'include',
                     }
                 );
 

--- a/frontend/src/app/campus/courses/page.tsx
+++ b/frontend/src/app/campus/courses/page.tsx
@@ -93,10 +93,15 @@ type SearchType = 'all' | 'name' | 'code' | 'department';
 
 /** Prefer API CxIDs when present on the course; otherwise legacy instructor ids. */
 function courseInstructorDisplayKeys(course: Course): number[] {
-    if (course.all_instructor_cxids && course.all_instructor_cxids.length > 0) {
+    if (
+        Array.isArray(course.all_instructor_cxids) &&
+        course.all_instructor_cxids.length > 0
+    ) {
         return course.all_instructor_cxids;
     }
-    return course.all_instructor_ids ?? [];
+    return Array.isArray(course.all_instructor_ids)
+        ? course.all_instructor_ids
+        : [];
 }
 
 function instructorForDisplayKey(
@@ -104,7 +109,10 @@ function instructorForDisplayKey(
     key: number,
     cache: Record<number, Instructor>
 ): Instructor | undefined {
-    if (course.all_instructor_cxids && course.all_instructor_cxids.length > 0) {
+    if (
+        Array.isArray(course.all_instructor_cxids) &&
+        course.all_instructor_cxids.length > 0
+    ) {
         return Object.values(cache).find((i) => i.cxids?.includes(key));
     }
     return cache[key];


### PR DESCRIPTION
## Context

- Course detail pages were showing "Instructor information unavailable for this review." for some reviews even though `instructor_cxid` was correctly set in the API response. The course search page was also crashing with "keys.map is not a function" for users on prod, preventing instructor names from rendering entirely.
- Follows from PR #157 (instructor CxID migration)

## Describe your changes

**Bug 1 — Instructor lookup fails on course detail page**

Two causes:
1. The `/api/courses/:id/instructors` endpoint was paginated with a default limit of 20. For courses with 21+ historical instructors, the frontend silently dropped data — reviews by instructors beyond page 1 couldn't be resolved.
2. Before `02-merge-instructor-duplicates` runs on prod, the same physical person exists as two docs (e.g. "Carlson, Kevin" with CxID 7002, and "Carlson, Kevin David" with CxID 5001). A review might have `instructor_cxid: 5001`, but the course's `all_instructor_cxids` only contains 7002 — so the endpoint returned only the Kevin doc, leaving `instructorByCxid[5001]` unpopulated. The legacy `instructorById` fallback also failed because Kevin David wasn't in the returned list at all.

Fixes:
- `frontend/src/app/campus/courses/[id]/page.tsx`: Fetch instructors with `limit=500` instead of the default 20.
- `backend/src/routes/CoursesRoutes.ts`: After the CxID-mode instructor lookup, run a supplemental query against `all_instructor_ids` and union in any docs not already found. This ensures `instructorById` works as a complete fallback for duplicate-doc edge cases.

**Bug 2 — "keys.map is not a function" crash on course search page**

Some older prod documents have `all_instructor_ids` or `all_instructor_cxids` stored as a non-array (e.g. a plain integer). The previous guard `value && value.length > 0` passes for truthy non-arrays, then `.map()` throws.

Fix:
- `frontend/src/app/campus/courses/page.tsx`: Changed guards in `courseInstructorDisplayKeys` and `instructorForDisplayKey` to use `Array.isArray()`.
- `backend/src/migration/07-coerce-array-fields.ts`: One-time migration script (dry-run by default) that finds all course documents where either field is not an array and coerces them — e.g. `5001 → [5001]`, missing → `[]`.

No breaking changes. The supplemental legacy lookup adds one extra DB query per `/instructors` request but only when `all_instructor_ids` is non-empty.

## Testing

Before: 
<img width="936" height="247" alt="{4B75A23C-56F0-4602-B544-8F4486C34DBC}" src="https://github.com/user-attachments/assets/fe68c7cb-f1f7-4bab-9d62-82fd2f05ee44" />

After: 
<img width="792" height="209" alt="{01DD75D5-1208-43CE-9D1D-DFECC5490A9D}" src="https://github.com/user-attachments/assets/c7d33fe9-0c83-44d1-805f-2d25d69ff03e" />
