### PR TITLE
Add a missing return in HousingRoutes

### DIFF
--- a/backend/src/routes/HousingRoutes.ts
+++ b/backend/src/routes/HousingRoutes.ts
@@ -507,6 +507,7 @@ router.delete(
 
             if (!review) {
                 res.status(404).json({ message: 'Review not found' });
+                return;
             }
 
             res.status(200).json({ message: 'Review deleted' });


### PR DESCRIPTION
## Context

Missing return in an edge case check in `DELETE /api/campus/housing/reviews/:id` route. If trying to delete a non-existent review, we would get both a 404 and a 200.

