### PR TITLE
fix: refresh stale homepage copy and resolve double loading state

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Loading from '@/components/Loading';
+import HomepageSkeleton from '@/components/HomepageSkeleton';
 import HomepageEvents from '@/components/ui/HomepageEvents';
 import BallotCountdown from '@/components/vote/BallotCountdown';
 import { useAuth } from '@/hooks/useAuth';
@@ -8,9 +8,11 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
+const SUNSET_BLUR_DATA_URL =
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiA5Ij48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwIiB5MT0iMCIgeDI9IjAiIHkyPSIxIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNmZjk1NDIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiM4ZjQ2MjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iOSIgZmlsbD0idXJsKCNnKSIvPjwvc3ZnPg==';
+
 export default function HomePage() {
-    const [loading, setLoading] = useState(true);
-    const { user, loading: authLoading } = useAuth();
+    const { loading: authLoading } = useAuth();
     const [events, setEvents] = useState<Event[]>([]);
     const [election, setElection] = useState<IElectionFrontend | null>(null);
     const [showElection, setShowElection] = useState(false);
@@ -75,12 +77,10 @@ export default function HomePage() {
     }, []);
 
     if (authLoading) {
-        return <Loading />;
+        return <HomepageSkeleton />;
     }
     return (
         <div className="min-h-screen bg-white">
-            {loading && <Loading />}
-
             {/* Election Section - When there is active election */}
             {showElection && election && (
                 <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-[#0a0f1d]">
@@ -144,9 +144,8 @@ export default function HomePage() {
                     className="object-cover"
                     priority
                     quality={100}
-                    onLoadingComplete={() => {
-                        setTimeout(() => setLoading(false), 400);
-                    }}
+                    placeholder="blur"
+                    blurDataURL={SUNSET_BLUR_DATA_URL}
                 />
                 <div className="absolute inset-0 bg-orange-500/30 mix-blend-multiply" />
 
@@ -190,7 +189,7 @@ export default function HomePage() {
                         <div className="space-y-6">
                             <div className="bg-white rounded-lg shadow p-6">
                                 <h3 className="font-medium mb-2">
-                                    Fall 2025 Funding Request Forms
+                                    Spring 2026 Funding Request Forms
                                 </h3>
                                 <p className="text-gray-600 text-sm">
                                     Request funds allocated for conferences,

--- a/frontend/src/components/HomepageSkeleton.tsx
+++ b/frontend/src/components/HomepageSkeleton.tsx
@@ -1,0 +1,40 @@
+export default function HomepageSkeleton() {
+    return (
+        <div className="min-h-screen bg-white animate-pulse">
+            <div className="relative h-screen flex items-center justify-center bg-gradient-to-b from-orange-300 to-orange-600">
+                <div className="relative z-10 px-6 text-center">
+                    <div className="h-12 w-80 md:w-[28rem] bg-white/40 rounded mx-auto mb-4" />
+                    <div className="h-12 w-64 md:w-96 bg-white/40 rounded mx-auto" />
+                </div>
+            </div>
+
+            <div className="container mx-auto px-4 py-12">
+                <div className="grid md:grid-cols-2 gap-12">
+                    <section>
+                        <div className="h-7 w-48 bg-gray-200 rounded mb-6" />
+                        <div className="bg-white rounded-lg shadow p-6 space-y-4">
+                            <div className="h-4 w-full bg-gray-200 rounded" />
+                            <div className="h-4 w-5/6 bg-gray-200 rounded" />
+                            <div className="h-4 w-2/3 bg-gray-200 rounded" />
+                        </div>
+                    </section>
+                    <section>
+                        <div className="h-7 w-48 bg-gray-200 rounded mb-6" />
+                        <div className="space-y-6">
+                            <div className="bg-white rounded-lg shadow p-6 space-y-3">
+                                <div className="h-5 w-2/3 bg-gray-200 rounded" />
+                                <div className="h-3 w-full bg-gray-200 rounded" />
+                                <div className="h-3 w-4/5 bg-gray-200 rounded" />
+                            </div>
+                            <div className="bg-white rounded-lg shadow p-6 space-y-3">
+                                <div className="h-5 w-2/3 bg-gray-200 rounded" />
+                                <div className="h-3 w-full bg-gray-200 rounded" />
+                                <div className="h-3 w-4/5 bg-gray-200 rounded" />
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Context

- The homepage's "Latest From ASPC" section was hard-coded with year-old copy ("Fall 2025 Funding Request Forms"), and the loading flow stacked two full-screen spinners (one from `useAuth`, one from the hero image) before the page became usable. The image spinner also never fired on cached/fast loads.
- Short-term fix only — a "Pinned Announcements" CMS model is the longer-term solution and is out of scope for this PR.

## Describe your changes

- Update the funding-request copy from "Fall 2025" to "Spring 2026" so the homepage isn't shipping year-old content.
- Replace the full-screen `<Loading />` spinner shown during auth check with a new `HomepageSkeleton` that mirrors the homepage layout.
- Remove the racing image-load spinner (`loading` state + `onLoadingComplete`). The Next.js `<Image>` component now handles the transition via `placeholder="blur"` + an inline `blurDataURL` (a small base64-encoded SVG sunset gradient), which also works correctly on cached loads.
- Drop the unused `user` destructure from `useAuth()` in `page.tsx`.

No breaking changes or migration steps.

## Testing

- **API Routes**: No new/modified endpoints.
- **Unit Tests**: No helper functions added.
- **Screenshots**: Verify locally that:
  - Loading the homepage cold shows the skeleton during auth check, then transitions to the hero image with a smooth blur-up — no full-screen spinner.
  - Hard-refreshing with cache populated does not flash a spinner over the hero image.
  - The "Latest From ASPC" card now reads "Spring 2026 Funding Request Forms".