### PR TITLE
feat: share election fetch via useElection() hook

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,17 +3,17 @@ import Loading from '@/components/Loading';
 import HomepageEvents from '@/components/ui/HomepageEvents';
 import BallotCountdown from '@/components/vote/BallotCountdown';
 import { useAuth } from '@/hooks/useAuth';
-import { Event, IElectionFrontend } from '@/types';
+import { useElection } from '@/hooks/useElection';
+import { Event } from '@/types';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 export default function HomePage() {
     const [loading, setLoading] = useState(true);
-    const { user, loading: authLoading } = useAuth();
+    const { loading: authLoading } = useAuth();
     const [events, setEvents] = useState<Event[]>([]);
-    const [election, setElection] = useState<IElectionFrontend | null>(null);
-    const [showElection, setShowElection] = useState(false);
+    const { election, showElection } = useElection();
 
     useEffect(() => {
         const fetchEvents = async () => {
@@ -35,43 +35,6 @@ export default function HomePage() {
                     new Date(a.start).getTime() - new Date(b.start).getTime()
             )
         );
-    }, []);
-
-    useEffect(() => {
-        const fetchElection = async () => {
-            try {
-                const backendLink =
-                    process.env.BACKEND_LINK || process.env.BACKEND_LINK;
-                const electionRes = await fetch(
-                    `${backendLink}/api/voting/election`,
-                    {
-                        credentials: 'include',
-                    }
-                );
-
-                if (!electionRes.ok) {
-                    setShowElection(false);
-                    return;
-                }
-
-                const data = await electionRes.json();
-                const now = new Date();
-                const startDate = new Date(data.startDate);
-                const endDate = new Date(data.endDate);
-
-                if (startDate <= now && endDate > now) {
-                    setElection(data);
-                    setShowElection(true);
-                } else {
-                    setShowElection(false);
-                }
-            } catch (error) {
-                console.error('Error fetching election:', error);
-                setShowElection(false);
-            }
-        };
-
-        fetchElection();
     }, []);
 
     if (authLoading) {

--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Loading from '@/components/Loading';
 import { useAuth } from '@/hooks/useAuth';
+import { useElection } from '@/hooks/useElection';
 import { PageContent } from '@/types';
 import Image from 'next/image';
 import { Button } from './Button';
@@ -23,7 +24,7 @@ const Header = () => {
     const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
     const [loadingPages, setLoadingPages] = useState(true);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-    const [showElectionButton, setShowElectionButton] = useState(false);
+    const { showElection: showElectionButton } = useElection();
 
     useEffect(() => {
         const fetchPages = async () => {
@@ -66,41 +67,6 @@ const Header = () => {
 
         fetchPages();
     }, [user]);
-
-    useEffect(() => {
-        const fetchElection = async () => {
-            try {
-                const backendLink = process.env.BACKEND_LINK;
-                const electionRes = await fetch(
-                    `${backendLink}/api/voting/election`,
-                    {
-                        credentials: 'include',
-                    }
-                );
-
-                if (!electionRes.ok) {
-                    setShowElectionButton(false);
-                    return;
-                }
-
-                const data = await electionRes.json();
-                const now = new Date();
-                const startDate = new Date(data.startDate);
-                const endDate = new Date(data.endDate);
-
-                if (startDate <= now && endDate > now) {
-                    setShowElectionButton(true);
-                } else {
-                    setShowElectionButton(false);
-                }
-            } catch (error) {
-                console.error('Error fetching election:', error);
-                setShowElectionButton(false);
-            }
-        };
-
-        fetchElection();
-    }, []);
 
     const handleDropdownClick = (dropdownName: string) => {
         setOpenDropdown(openDropdown === dropdownName ? null : dropdownName);

--- a/frontend/src/hooks/useElection.ts
+++ b/frontend/src/hooks/useElection.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { IElectionFrontend } from '@/types';
+
+type ElectionResult = {
+    election: IElectionFrontend | null;
+    isActive: boolean;
+};
+
+const NO_ELECTION: ElectionResult = { election: null, isActive: false };
+
+let inflight: Promise<ElectionResult> | null = null;
+
+const fetchElection = async (): Promise<ElectionResult> => {
+    try {
+        const res = await fetch(
+            `${process.env.BACKEND_LINK}/api/voting/election`,
+            { credentials: 'include' }
+        );
+        if (!res.ok) return NO_ELECTION;
+
+        const data: IElectionFrontend = await res.json();
+        const now = new Date();
+        const isActive =
+            new Date(data.startDate) <= now && new Date(data.endDate) > now;
+        return { election: isActive ? data : null, isActive };
+    } catch (error) {
+        console.error('Error fetching election:', error);
+        return NO_ELECTION;
+    }
+};
+
+const getElection = (): Promise<ElectionResult> => {
+    if (!inflight) {
+        inflight = fetchElection();
+    }
+    return inflight;
+};
+
+export function useElection() {
+    const [result, setResult] = useState<ElectionResult>(NO_ELECTION);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        getElection().then((r) => {
+            if (!cancelled) {
+                setResult(r);
+                setLoading(false);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return {
+        election: result.election,
+        showElection: result.isActive,
+        loading,
+    };
+}


### PR DESCRIPTION
## Context

- `Header.tsx` and `app/page.tsx` were each running their own `useEffect` + `fetch` against `GET /api/voting/election` on every page load — two network round trips for the same data, with the same active-window check (`startDate <= now < endDate`) duplicated in both files.
- Goal: one fetch per page load, shared by both consumers, mirroring the pattern already established by `useAuth()`.

## Describe your changes

- New `useElection()` hook in `frontend/src/hooks/useElection.ts`. Returns `{ election, showElection, loading }`.
- Uses a module-level in-flight promise so the second consumer to mount subscribes to the first consumer's fetch instead of starting its own — no new dependency needed (SWR/react-query not required for this simple case).
- `Header.tsx` and `page.tsx` now both consume `useElection()`; their inline `useEffect` + fetch + active-window logic is removed (~50 lines deleted across the two files).

No breaking changes. Public API of the hook intentionally matches what each consumer previously held in local state.

## Testing

- **API Routes**: No new/modified endpoints. Verify in DevTools → Network that loading the homepage now triggers exactly **one** request to `/api/voting/election` (previously two).
- **Unit Tests**: None added — the hook is a thin wrapper around `fetch` and a date comparison.
- **Screenshots**: Verify locally that:
  - With an active election: the homepage hero election section AND the header "VOTE HERE" button both render.
  - With no active election (or 404 / window closed): neither renders.
  - `npx tsc --noEmit` passes.